### PR TITLE
Remove Firebase/Messaging iOS pinned version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Firebase/Messaging" spec="~> 6.23.0" />
+                <pod name="Firebase/Messaging" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
The recommended approach is to reference the `Firebase/Messaging` without a version; this also helps to prevent missing pod dependencies.